### PR TITLE
Fix Platform.worker (cmd)

### DIFF
--- a/src/Platform.gren
+++ b/src/Platform.gren
@@ -72,8 +72,8 @@ module has a few ways to create that kind of `Program` instead!
 
 -}
 worker :
-    { init : flags -> { model : model, cmd : Cmd msg }
-    , update : msg -> model -> { model : model, cmd : Cmd msg }
+    { init : flags -> { model : model, command : Cmd msg }
+    , update : msg -> model -> { model : model, command : Cmd msg }
     , subscriptions : model -> Sub msg
     }
     -> Program flags model msg


### PR DESCRIPTION
In Platform.worker, the type signature for model and command is:
```{ model, cmd }```
this currently crashes as the code for Platform.worker expect it to be:
``` { model, command }```   (same as the Browser programs)