### PR TITLE
Make `Process.kill` not crash when run multiple times

### DIFF
--- a/src/Gren/Kernel/Scheduler.js
+++ b/src/Gren/Kernel/Scheduler.js
@@ -90,7 +90,7 @@ var _Scheduler_send = F2(function (proc, msg) {
 function _Scheduler_kill(proc) {
   return _Scheduler_binding(function (callback) {
     var task = proc.__root;
-    if (task.$ === __1_BINDING && task.__kill) {
+    if (task && task.$ === __1_BINDING && task.__kill) {
       task.__kill();
     }
 


### PR DESCRIPTION
## Context

- Issue: #35

The bug was originating from the Kernel `_Scheduler_kill` function: 

- some of the task fields are fetched
- the task is set to null after being killed

So if we try to kill the same task a second time, the Kernel tries to fetch the fields of a null object, which makes it crash.

## Changes

In the condition getting the fields of the task, we're now checking that the task is not null beforehand.