### PR TITLE
Remove references to automatic record constructors

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -4,3 +4,4 @@ Julian Antonielli
 Gaute Berge
 Alexis Lozano
 Ju Liu
+William Ashton

--- a/src/Bytes/Decode.gren
+++ b/src/Bytes/Decode.gren
@@ -208,16 +208,23 @@ map func (Decoder decodeA) =
 
 {-| Combine two decoders.
 
-    import Bytes exposing (Endiannness(..))
+    import Bytes exposing ( Endianness(..) )
     import Bytes.Decode as Decode
 
-    type alias Point = { x : Float, y : Float }
+    type alias Point =
+        { x : Float
+        , y : Float
+        }
+
+    makePoint : Float -> Float -> Point
+    makePoint x y =
+        { x = x
+        , y = y
+        }
 
     decoder : Decode.Decoder Point
     decoder =
-      Decode.map2 Point
-        (Decode.float32 BE)
-        (Decode.float32 BE)
+        Decode.map2 makePoint (Decode.float32 BE) (Decode.float32 BE)
 -}
 map2 : (a -> b -> result) -> Decoder a -> Decoder b -> Decoder result
 map2 func (Decoder decodeA) (Decoder decodeB) =

--- a/src/Bytes/Encode.gren
+++ b/src/Bytes/Encode.gren
@@ -91,7 +91,7 @@ value directly. This is valuable when you are encoding more elaborate data:
         , Encode.string person.name
         ]
 
-    -- encode (toEncoder (Person 33 "Tom")) == <00210003546F6D>
+    -- encode (toEncoder ({ age = 33, name = "Tom" })) == <00210003546F6D>
 
 Did you know it was going to be seven bytes? How about when you have a hundred
 people to serialize? And when some have Japanese and Norwegian names? Having

--- a/src/Dict.gren
+++ b/src/Dict.gren
@@ -64,14 +64,20 @@ type NColor
 that lets you look up a `String` (such as user names) and find the associated
 `User`.
 
-    import Dict exposing (Dict)
+    import Dict exposing ( Dict )
 
     users : Dict String User
     users =
         Dict.fromArray
-            [ ( "Alice", User "Alice" 28 1.65 )
-            , ( "Bob", User "Bob" 19 1.82 )
-            , ( "Chuck", User "Chuck" 33 1.75 )
+            [ { key = "Alice"
+              , value = makeUser "Alice" 28 1.65
+              }
+            , { key = "Bob"
+              , value = makeUser "Bob" 19 1.82
+              }
+            , { key = "Chuck"
+              , value = makeUser "Chuck" 33 1.75
+              }
             ]
 
     type alias User =
@@ -80,6 +86,12 @@ that lets you look up a `String` (such as user names) and find the associated
         , height : Float
         }
 
+    makeUser : String -> Int -> Float -> User
+    makeUser name age height =
+        { name = name
+        , age = age
+        , height = height
+        }
 -}
 type Dict k v
     = RBNode_gren_builtin NColor k v (Dict k v) (Dict k v)

--- a/src/Json/Decode.gren
+++ b/src/Json/Decode.gren
@@ -173,7 +173,7 @@ If you need the keys (like `"alice"` and `"bob"`) available in the `Dict`
 values as well, I recommend using a (private) intermediate data structure like
 `Info` in this example:
 
-    module User exposing (User, decoder)
+    module User exposing ( User, decoder )
 
     import Dict
     import Json.Decode exposing (..)
@@ -182,6 +182,13 @@ values as well, I recommend using a (private) intermediate data structure like
         { name : String
         , height : Float
         , age : Int
+        }
+
+    makeUser : String -> Float -> Int -> User
+    makeUser name height age =
+        { name = name
+        , height = height
+        , age = age
         }
 
     decoder : Decoder (Dict.Dict String User)
@@ -193,15 +200,21 @@ values as well, I recommend using a (private) intermediate data structure like
         , age : Int
         }
 
+    makeInfo : Float -> Int -> Info
+    makeInfo height age =
+        { height = height
+        , age = age
+        }
+
     infoDecoder : Decoder Info
     infoDecoder =
-        map2 Info
+        map2 makeInfo
             (field "height" float)
             (field "age" int)
 
     infoToUser : String -> Info -> User
     infoToUser name { height, age } =
-        User name height age
+        makeUser name height age
 
 So now JSON like `{ "alice": { height: 1.6, age: 33 }}` are turned into
 dictionary values like `Dict.singleton "alice" (User "alice" 1.6 33)` if
@@ -407,13 +420,19 @@ objects with many fields:
 
 
     type alias Point =
-        { x : Float, y : Float }
+        { x : Float
+        , y : Float
+        }
+
+    makePoint : Float -> Float -> Point
+    makePoint x y =
+        { x = x
+        , y = y
+        }
 
     point : Decoder Point
     point =
-        map2 Point
-            (field "x" float)
-            (field "y" float)
+        map2 makePoint (field "x" float) (field "y" float)
 
     -- decodeString point """{ "x": 3, "y": 4 }""" == Ok { x = 3, y = 4 }
 
@@ -433,9 +452,16 @@ objects with many fields:
     type alias Person =
         { name : String, age : Int, height : Float }
 
+    makePerson : String -> Int -> Float -> Person
+    makePerson name age height =
+        { name = name
+        , age = age
+        , height = height
+        }
+
     person : Decoder Person
     person =
-        map3 Person
+        map3 makePerson
             (at [ "name" ] string)
             (at [ "info", "age" ] int)
             (at [ "info", "height" ] float)
@@ -700,12 +726,18 @@ You can use `lazy` to make sure your decoder unrolls lazily.
         , responses : Responses
         }
 
+    makeComment : String -> Responses -> Comment
+    makeComment message responses =
+        { message = message
+        , responses = responses
+        }
+
     type Responses
         = Responses (Array Comment)
 
     comment : Decoder Comment
     comment =
-        map2 Comment
+        map2 makeComment
             (field "message" string)
             (field "responses" (map Responses (array (lazy (\_ -> comment)))))
 


### PR DESCRIPTION
Fixes #62 

I found this list of issues by searching this repo for instances of `type alias` inside a comment, and then looking at how those type aliases were used. This means that there may be other instances of this pattern that still need to be cleaned up, if the type was not introduced in the documentation with `type alias`.

These changes in these examples compiled successfully using the Green 2.1 compiler (after adding the necessary `module` and `import` statements. Going through that check revealed a couple other issues as well.

* `Dict.Dict` had an example with Tuples
* `Bytes.Decode.map2` tried to expose `Bytes.Endiannness` (with three 'n's)