### PR TITLE
Replace mentions of lists by arrays in docs and code

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -7,3 +7,4 @@ Ju Liu
 William Ashton
 Revath S Kumar
 Justin Blake
+Jeroen Engels

--- a/src/Array.gren
+++ b/src/Array.gren
@@ -101,7 +101,7 @@ repeat n val =
     initialize n 0 (\_ -> val)
 
 
-{-| Create a list of numbers, every element increasing by one. You give the lowest and highest number that should be in the list.
+{-| Create an array of numbers, every element increasing by one. You give the lowest and highest number that should be in the array.
 
     range 3 6 == [3, 4, 5, 6]
     range 3 3 == [3]
@@ -336,7 +336,7 @@ all fn array =
             True
 
 
-{-| Find the minimum element in a non-empty list.
+{-| Find the minimum element in a non-empty array.
 
     minimum [3,2,1] == Just 1
     minimum []      == Nothing
@@ -362,7 +362,7 @@ minimum array =
                     array
 
 
-{-| Find the maximum element in a non-empty list.
+{-| Find the maximum element in a non-empty array.
 
     maximum [3,2,1] == Just 3
     maximum []      == Nothing
@@ -490,7 +490,7 @@ flatMap =
     Gren.Kernel.Array.flatMap
 
 
-{-| Places the given value between all members of the given list.
+{-| Places the given value between all members of the given array.
 
     intersperse "on" [ "turtles", "turtles", "turtles"] == [ "turtles", "on", "turtles", "on", "turtles"]
 

--- a/src/Basics.gren
+++ b/src/Basics.gren
@@ -39,7 +39,7 @@ characters, strings and arrays of comparable things.
 @docs Bool, not, (&&), (||), xor
 
 
-## Append Strings and Lists
+## Append Strings and Arrays
 
 @docs (++)
 
@@ -152,12 +152,12 @@ can do things like this:
 
 You _cannot_ add an `Int` and a `Float` directly though. Use functions like
 [toFloat](#toFloat) or [round](#round) to convert both values to the same type.
-So if you needed to add a list length to a `Float` for some reason, you
+So if you needed to add a array length to a `Float` for some reason, you
 could say one of these:
 
-    3.14 + toFloat (List.length [ 1, 2, 3 ]) == 6.14
+    3.14 + toFloat (Array.length [ 1, 2, 3 ]) == 6.14
 
-    round 3.14 + List.length [ 1, 2, 3 ] == 6
+    round 3.14 + Array.length [ 1, 2, 3 ] == 6
 
 **Note:** Languages like Java and JavaScript automatically convert `Int` values
 to `Float` values when you mix and match. This can make it difficult to be sure
@@ -415,7 +415,7 @@ clamp low high number =
 
 
 {-| Compare any two comparable values. Comparable values include `String`,
-`Char`, `Int`, `Float`, or a list or tuple containing comparable values. These
+`Char`, `Int`, `Float`, or an array or tuple containing comparable values. These
 are also the only values that work as `Dict` keys or `Set` members.
 
     compare 3 4 == LT
@@ -532,7 +532,7 @@ xor =
 -- APPEND
 
 
-{-| Put two appendable things together. This includes strings and lists.
+{-| Put two appendable things together. This includes strings and arrays.
 
     "hello" ++ "world" == "helloworld"
 

--- a/src/Bytes/Decode.gren
+++ b/src/Bytes/Decode.gren
@@ -390,7 +390,7 @@ fail =
 
 If you are `Done`, you give the result of the whole `loop`. If you decide to
 `Loop` around again, you give a new state to work from. Maybe you need to add
-an item to a list? Or maybe you need to track some information about what you
+an item to an array? Or maybe you need to track some information about what you
 just saw?
 
 **Note:** It may be helpful to learn about [finite-state machines][fsm] to get
@@ -406,24 +406,24 @@ type Step state a
 
 
 {-| A decoder that can loop indefinitely. This can be helpful when parsing
-repeated structures, like a list:
+repeated structures, like an array:
 
     import Bytes exposing (Endianness(..))
     import Bytes.Decode as Decode exposing (..)
 
-    list : Decoder a -> Decoder (Array a)
-    list decoder =
+    array : Decoder a -> Decoder (Array a)
+    array decoder =
       unsignedInt32 BE
-        |> andThen (\len -> loop (len, []) (listStep decoder))
+        |> andThen (\len -> loop (len, []) (arrayStep decoder))
 
-    listStep : Decoder a -> { fst : Int, snd : Array a } -> Decoder (Step { fst Int, snd : Array a } (Array a))
-    listStep decoder (n, xs) =
+    arrayStep : Decoder a -> { fst : Int, snd : Array a } -> Decoder (Step { fst Int, snd : Array a } (Array a))
+    arrayStep decoder (n, xs) =
       if n <= 0 then
         succeed (Done xs)
       else
         map (\x -> Loop (n - 1, x :: xs)) decoder
 
-The `list` decoder first reads a 32-bit unsigned integer. That determines how
+The `array` decoder first reads a 32-bit unsigned integer. That determines how
 many items will be decoded. From there we use [`loop`](#loop) to track all the
 items we have parsed so far and figure out when to stop.
 -}

--- a/src/Dict.gren
+++ b/src/Dict.gren
@@ -690,7 +690,7 @@ partition isGood dict =
 
 
 
--- LISTS
+-- ARRAYS
 
 
 {-| Get all of the keys in a dictionary, sorted from lowest to highest.
@@ -733,31 +733,31 @@ merge :
     -> result
 merge leftStep bothStep rightStep leftDict rightDict initialResult =
     let
-        stepState rKey rValue { list, result } =
-            case Array.popFirst list of
+        stepState rKey rValue { array, result } =
+            case Array.popFirst array of
                 Nothing ->
-                    { list = list
+                    { array = array
                     , result = rightStep rKey rValue result
                     }
 
                 Just { first = { key = lKey, value = lValue }, rest } ->
                     if lKey < rKey then
                         stepState rKey rValue 
-                            { list = rest
+                            { array = rest
                             , result = leftStep lKey lValue result
                             }
 
                     else if lKey > rKey then
-                        { list = list
+                        { array = array
                         , result = rightStep rKey rValue result
                         }
 
                     else
-                        { list = rest
+                        { array = rest
                         , result = bothStep lKey lValue rValue result
                         }
 
-        { list = leftovers, result = intermediateResult } =
-            foldl stepState { list = foldl (\key value array -> Array.pushLast { key = key, value = value } array) [] leftDict, result = initialResult } rightDict
+        { array = leftovers, result = intermediateResult } =
+            foldl stepState { array = foldl (\key value array -> Array.pushLast { key = key, value = value } array) [] leftDict, result = initialResult } rightDict
     in
     Array.foldl (\{ key, value } result -> leftStep key value result) intermediateResult leftovers

--- a/src/Gren/Kernel/Platform.js
+++ b/src/Gren/Kernel/Platform.js
@@ -164,10 +164,10 @@ function _Platform_leaf(home) {
   };
 }
 
-function _Platform_batch(list) {
+function _Platform_batch(array) {
   return {
     $: __2_NODE,
-    __bags: list,
+    __bags: array,
   };
 }
 

--- a/src/Set.gren
+++ b/src/Set.gren
@@ -177,8 +177,8 @@ toArray (Set_gren_builtin dict) =
 {-| Convert an array into a set, removing any duplicates.
 -}
 fromArray : Array comparable -> Set comparable
-fromArray list =
-    Array.foldl set empty list
+fromArray array =
+    Array.foldl set empty array
 
 
 {-| Fold over the values in a set, in order from lowest to highest.

--- a/src/Set.gren
+++ b/src/Set.gren
@@ -8,7 +8,7 @@ module Set exposing
     )
 
 {-| A set of unique values. The values can be any comparable type. This
-includes `Int`, `Float`, `Time`, `Char`, `String`, and tuples or lists
+includes `Int`, `Float`, `Time`, `Char`, `String`, and tuples or arrays
 of comparable types.
 
 Set, remove, and query operations all take _O(log n)_ time.
@@ -167,14 +167,14 @@ diff (Set_gren_builtin dict1) (Set_gren_builtin dict2) =
     Set_gren_builtin (Dict.diff dict1 dict2)
 
 
-{-| Convert a set into a list, sorted from lowest to highest.
+{-| Convert a set into an array, sorted from lowest to highest.
 -}
 toArray : Set a -> Array a
 toArray (Set_gren_builtin dict) =
     Dict.keys dict
 
 
-{-| Convert a list into a set, removing any duplicates.
+{-| Convert an array into a set, removing any duplicates.
 -}
 fromArray : Array comparable -> Set comparable
 fromArray list =

--- a/src/String.gren
+++ b/src/String.gren
@@ -267,7 +267,7 @@ lines =
 
 
 {-| Take a substring given a start and end index. Negative indexes
-are taken starting from the _end_ of the list.
+are taken starting from the _end_ of the array.
 
     slice 7 9 "snakes on a plane!" == "on"
 
@@ -586,7 +586,7 @@ fromFloat =
 -- LIST CONVERSIONS
 
 
-{-| Convert a string to a list of characters.
+{-| Convert a string to an array of characters.
 
     toArray "abc" == [ 'a', 'b', 'c' ]
 
@@ -598,7 +598,7 @@ toArray string =
     foldl Array.pushLast [] string
 
 
-{-| Convert a list of characters into a String. Can be useful if you
+{-| Convert an array of characters into a String. Can be useful if you
 want to create a string primarily by consing, perhaps for decoding
 something.
 
@@ -637,7 +637,7 @@ cons =
 
 
 {-| Split a non-empty string into its head and tail. This lets you
-pattern match on strings exactly as you would with lists.
+pattern match on strings exactly as you would with arrays.
 
     uncons "abc" == Just ( 'a', "bc" )
 

--- a/src/String.gren
+++ b/src/String.gren
@@ -583,7 +583,7 @@ fromFloat =
 
 
 
--- LIST CONVERSIONS
+-- ARRAY CONVERSIONS
 
 
 {-| Convert a string to an array of characters.

--- a/src/Task.gren
+++ b/src/Task.gren
@@ -211,8 +211,8 @@ map5 func taskA taskB taskC taskD taskE =
             )
 
 
-{-| Start with a list of tasks, and turn them into a single task that returns a
-list. The tasks will be run in order one-by-one and if any task fails the whole
+{-| Start with an array of tasks, and turn them into a single task that returns a
+array. The tasks will be run in order one-by-one and if any task fails the whole
 sequence fails.
 
     sequence [ succeed 1, succeed 2 ] == succeed [ 1, 2 ]

--- a/src/Time.gren
+++ b/src/Time.gren
@@ -542,7 +542,7 @@ function is a stopgap that takes:
 
 1. A default offset in minutes. So `Etc/GMT-5` is `customZone (-5 * 60) []`
 and `Etc/GMT+9` is `customZone (9 * 60) []`.
-2. A list of exceptions containing their `start` time in "minutes since the Unix
+2. An array of exceptions containing their `start` time in "minutes since the Unix
 epoch" and their `offset` in "minutes from UTC"
 
 Human times will be based on the nearest `start`, falling back on the default

--- a/tests/src/Test/Char.gren
+++ b/tests/src/Test/Char.gren
@@ -48,8 +48,8 @@ decCodes =
 
 
 oneOf : Array a -> a -> Bool
-oneOf list e =
-    Array.member e list
+oneOf array e =
+    Array.member e array
 
 
 tests : Test

--- a/tests/src/Test/Equality.gren
+++ b/tests/src/Test/Equality.gren
@@ -32,7 +32,7 @@ tests =
                 , test "ctor diff, special case" <| \{} -> Expect.equal True ({ ctor = Just 3 } /= { ctor = Nothing })
                 ]
 
-        listTests =
+        arrayTests =
             describe "Array equality"
                 [ fuzz2 (Fuzz.intRange 100 10000) (Fuzz.intRange 100 10000) "Simple comparison" <|
                     \size1 size2 ->
@@ -41,4 +41,4 @@ tests =
                             (Array.range 0 size1 == Array.range 0 size2)
                 ]
     in
-    describe "Equality Tests" [ diffTests, recordTests, listTests ]
+    describe "Equality Tests" [ diffTests, recordTests, arrayTests ]

--- a/tests/src/Test/Set.gren
+++ b/tests/src/Test/Set.gren
@@ -255,21 +255,21 @@ diffTests =
 
 toArrayTests : Array Test
 toArrayTests =
-    [ test "returns empty list for empty set" <|
+    [ test "returns empty array for empty set" <|
         \{} -> Expect.equal [] (Set.toArray Set.empty)
-    , test "returns singleton list for singleton set" <|
+    , test "returns singleton array for singleton set" <|
         \{} -> Expect.equal [ 42 ] (Set.toArray set42)
-    , test "returns sorted list of set elements" <|
+    , test "returns sorted array of set elements" <|
         \{} -> Expect.equal (Array.range 1 100) (Set.toArray set1To100)
     ]
 
 
 fromArrayTests : Array Test
 fromArrayTests =
-    [ test "returns empty set for empty list" <|
+    [ test "returns empty set for empty array" <|
         \{} -> Expect.equal Set.empty (Set.fromArray [])
-    , test "returns singleton set for singleton list" <|
+    , test "returns singleton set for singleton array" <|
         \{} -> Expect.equal set42 (Set.fromArray [ 42 ])
-    , test "returns set with unique list elements" <|
+    , test "returns set with unique array elements" <|
         \{} -> Expect.equal set1To100 (Set.fromArray (Array.pushFirst 1 <| Array.range 1 100))
     ]


### PR DESCRIPTION
Hello good folks :wave: 

The docs still contained a lot of references to the defunct `List`, so I replaced it by mentions to `Array`.

Similarly, I also discovered variables that should have been renamed to array, so I did that.
Let me know if you want me to edit anything.