### PR TITLE
Fix typo in Task documentation

### DIFF
--- a/src/Task.gren
+++ b/src/Task.gren
@@ -203,7 +203,7 @@ array. The tasks will be run concurrently and if any task fails the whole array 
 
     concurrent [ succeed 1, succeed 2 ] == succeed [ 1, 2 ]
 
-Additionally if any task fails, any tasks already in-flight will be cleaned up (e.g. an in-flgiht http request will be cancelled).
+Additionally if any task fails, any tasks already in-flight will be cleaned up (e.g. an in-flight http request will be cancelled).
 
 **Note**: Why use `sequence` over `concurrent`? Maybe you have an expensive operation, like making 100 http requests.
 You might want to do these sequentially rather than all at once to avoid overwhelming the server.


### PR DESCRIPTION
Additional feedback, but I guess this is more up to discussion so not including here:
- There is inconsistency in the use of qualified imports: I see for instance mentions of `Task.map2` but then also unqualified `andMap`s. (Personnel recommendation: Use qualified imports everywhere)
- I *think* "single-threaded" is more correct than "single threaded"
- "http request" should be "HTTP request"
- In `Task.concurrent`, I would add a section on the difference (in terms of execution and performance) between `Task.concurrent [ a, b ] |> Task.perform X` and `Cmd.batch [ a |> Task.perform X, b |> Task.perform X ]`.