### PR TITLE
Speed up platform effects queue by looping through active effects

### DIFF
--- a/src/Gren/Kernel/Platform.js
+++ b/src/Gren/Kernel/Platform.js
@@ -223,8 +223,13 @@ function _Platform_enqueueEffects(managers, cmdBag, subBag) {
   if (_Platform_effectsActive) return;
 
   _Platform_effectsActive = true;
-  for (var fx; (fx = _Platform_effectsQueue.shift()); ) {
-    _Platform_dispatchEffects(fx.__managers, fx.__cmdBag, fx.__subBag);
+  while (_Platform_effectsQueue.length > 0) {
+    const activeEffects = _Platform_effectsQueue;
+    _Platform_effectsQueue = [];
+
+    for (const fx of activeEffects) {
+      _Platform_dispatchEffects(fx.__managers, fx.__cmdBag, fx.__subBag);
+    }
   }
   _Platform_effectsActive = false;
 }


### PR DESCRIPTION
This uses the same technique in 489d08c to avoid the use of `Array.shift`. This should speed up `Cmd.batch` when dispatching large arrays of commands.