### PR TITLE
Fix Stream.closeWritable to await close completion

### DIFF
--- a/devbox.lock
+++ b/devbox.lock
@@ -103,7 +103,7 @@
     },
     "nodejs@20": {
       "last_modified": "2025-09-21T09:21:16Z",
-      "plugin_version": "0.0.2",
+      "plugin_version": "0.0.4",
       "resolved": "github:NixOS/nixpkgs/a1f79a1770d05af18111fbbe2a3ab2c42c0f6cd0#nodejs_20",
       "source": "devbox-search",
       "version": "20.19.5",

--- a/src/Gren/Kernel/Stream.js
+++ b/src/Gren/Kernel/Stream.js
@@ -135,10 +135,20 @@ var _Stream_closeWritable = function (stream) {
     }
 
     const writer = stream.getWriter();
-    writer.close();
-    writer.releaseLock();
-
-    callback(__Scheduler_succeed({}));
+    writer
+      .close()
+      .then(() => {
+        writer.releaseLock();
+        callback(__Scheduler_succeed({}));
+      })
+      .catch((err) => {
+        writer.releaseLock();
+        callback(
+          __Scheduler_fail(
+            __Stream_Cancelled(_Stream_cancellationErrorString(err)),
+          ),
+        );
+      });
   });
 };
 

--- a/tests/gren.json
+++ b/tests/gren.json
@@ -4,7 +4,7 @@
     "source-directories": [
         "src"
     ],
-    "gren-version": "0.6.3",
+    "gren-version": "0.6.5",
     "dependencies": {
         "direct": {
             "gren-lang/core": "local:../",


### PR DESCRIPTION
# Fix `Stream.closeWritable` to await close completion and surface errors

## Problem
`_Stream_closeWritable` in `src/Gren/Kernel/Stream.js` was fire-and-forget:

```js
const writer = stream.getWriter();
writer.close();          // promise ignored
writer.releaseLock();
callback(__Scheduler_succeed({}));
```

`writer.close()` returns a promise that settles only once the underlying sink has actually closed. By ignoring it, the function had two correctness bugs:

1. **Premature success.** The `Task` resolved synchronously — before the stream had actually closed. Any caller chaining on the result (`Task.andThen`) would proceed as though the stream were closed when it wasn't yet.
2. **Silently swallowed errors.** If closing failed (the sink rejected, or the stream errored mid-close), the `writer.close()` promise rejected with no listener. The unhandled rejection was lost, and the `Task` still reported success — callers could never learn the close failed.

## Fix
Await `writer.close()` and route its outcome to the Scheduler callback:

```js
writer
  .close()
  .then(() => {
    writer.releaseLock();
    callback(__Scheduler_succeed({}));
  })
  .catch((err) => {
    writer.releaseLock();
    callback(
      __Scheduler_fail(
        __Stream_Cancelled(_Stream_cancellationErrorString(err)),
      ),
    );
  });
```

The `.catch` path reuses the existing `_Stream_cancellationErrorString` helper, matching how `_Stream_read` already reports failures as `Stream.Cancelled`.

## Behavior changes
- `closeWritable` now resolves only after the stream has actually closed, so chained tasks observe correct sequencing.
- Close failures are now surfaced as `Stream.Cancelled <message>` instead of being swallowed and falsely reported as success.
- The writer lock is now released *after* `close()` settles (in both branches), rather than synchronously before close completes.
